### PR TITLE
Add `provides` statement for compatibility with Chef 13

### DIFF
--- a/libraries/cookbook_versions_provider.rb
+++ b/libraries/cookbook_versions_provider.rb
@@ -4,6 +4,7 @@ require 'chef/provider/lwrp_base'
 class Chef
   class Provider
     class CookbookVersions < Chef::Provider::LWRPBase
+      provides :cookbook_versions
       use_inline_resources
 
       action :create do


### PR DESCRIPTION
Chef Client, version 12.9.41 complains with:

```
WARN: Class Chef::Provider::CookbookVersions does not declare 'provides :cookbook_versions'.
WARN: This will no longer work in Chef 13: you must use 'provides' to use the resource's DSL.
```

This change removes the warning and hopefully makes CookbookVersions actually compatible with Chef 13. This fixes #1.
