### PR TITLE
Fix #3: Include all cookbooks, even if they don't have a recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,15 @@ You can use the resource directly, or include the default recipe which simply ca
 ```ruby
 cookbook_versions 'whatever'
 ```
+
+## What is included
+
+By default, cookbook_versions includes only cookbooks that have a recipe in the run_list.
+This will not include cookbooks that provide resources but don't have recipes.
+You can change this behavior by either using the `cookbook_versions::all` recipe instead of the default recipe in your `run_list`, or by passing the `all_cookbooks true` attribute to the resource:
+
+```ruby
+cookbook_versions 'whatever' do
+  all_cookbooks true
+end
+```

--- a/libraries/cookbook_versions_provider.rb
+++ b/libraries/cookbook_versions_provider.rb
@@ -7,7 +7,11 @@ class Chef
       use_inline_resources
 
       action :create do
-        cookbook_versions = versioned_run_list(run_context.cookbook_collection.keys, run_context.cookbook_collection)
+        if new_resource.all_cookbooks
+          cookbook_versions = versioned_run_list(run_context.cookbook_collection.keys, run_context.cookbook_collection)
+        else
+          cookbook_versions = versioned_run_list(run_context.loaded_recipes, run_context.cookbook_collection)
+        end
         log("cookbook_versions:  #{cookbook_versions}")
         node.set['cookbook_versions'] = cookbook_versions
         node.save

--- a/libraries/cookbook_versions_provider.rb
+++ b/libraries/cookbook_versions_provider.rb
@@ -7,7 +7,7 @@ class Chef
       use_inline_resources
 
       action :create do
-        cookbook_versions = versioned_run_list(run_context.loaded_recipes, run_context.cookbook_collection)
+        cookbook_versions = versioned_run_list(run_context.cookbook_collection.keys, run_context.cookbook_collection)
         log("cookbook_versions:  #{cookbook_versions}")
         node.set['cookbook_versions'] = cookbook_versions
         node.save

--- a/libraries/cookbook_versions_resource.rb
+++ b/libraries/cookbook_versions_resource.rb
@@ -7,6 +7,7 @@ class Chef
       self.resource_name = :cookbook_versions
       actions :create
       default_action :create
+      attribute :all_cookbooks, :name_attribute => false, :kind_of => [TrueClass, FalseClass], :required => false, :default => false
     end
   end
 end

--- a/recipes/all.rb
+++ b/recipes/all.rb
@@ -1,0 +1,10 @@
+#
+# Cookbook Name:: cookbook_versions
+# Recipe:: default
+#
+# Copyright (c) 2015 Irving Popovetsky, All Rights Reserved.
+
+
+cookbook_versions node.name do
+  all_cookbooks true
+end


### PR DESCRIPTION
Cookbooks may provide resources that get executed and make changes to the node. 
This change includes all of the cookbooks, not only the ones with recipes in the run-list.

Fixes #3.
